### PR TITLE
Add Translation Requests Parallelization

### DIFF
--- a/Sources/SwiftTranslate/FileTranslators/StringCatalogTranslator.swift
+++ b/Sources/SwiftTranslate/FileTranslators/StringCatalogTranslator.swift
@@ -61,32 +61,33 @@ struct StringCatalogTranslator: FileTranslator {
             return
         }
         Log.info(newline: verbose ? .before : .none, "Translating key `\(key.truncatedRemovingNewlines(to: 64))` " + "[Comment: \(localizableStringGroup.comment ?? "n/a")]".dim)
-        
-        for localizableString in localizableStringGroup.strings {
-            let isSource = catalog.sourceLanguage == localizableString.targetLanguage
-            let targetLanguage = localizableString.targetLanguage
-            
-            if localizableString.state == .translated || isSource {
-                if verbose {
-                    let result = isSource 
+
+        await withThrowingTaskGroup(of: Void.self) { taskGroup in
+            for localizableString in localizableStringGroup.strings {
+                let isSource = catalog.sourceLanguage == localizableString.targetLanguage
+                let targetLanguage = localizableString.targetLanguage
+
+                if localizableString.state == .translated || isSource {
+                    if verbose {
+                        let result = isSource
                         ? localizableString.sourceKey.truncatedRemovingNewlines(to: 64)
                         : "[Already translated]".dim
-                    logTranslationResult(to: targetLanguage, result: result, isSource: isSource)
+                        logTranslationResult(to: targetLanguage, result: result, isSource: isSource)
+                    }
+                    continue
                 }
-                continue
-            }
-            do {
-                let translatedString = try await service.translate(
-                    localizableString.sourceKey,
-                    to: targetLanguage,
-                    comment: localizableStringGroup.comment
-                )
-                localizableString.setTranslation(translatedString)
-                if verbose {
-                    logTranslationResult(to: targetLanguage, result: translatedString.truncatedRemovingNewlines(to: 64), isSource: isSource)
+
+                taskGroup.addTask {
+                    do {
+                        let translatedString = try await service.translate(localizableString.sourceKey, to: targetLanguage, comment: localizableStringGroup.comment)
+                        localizableString.setTranslation(translatedString)
+                        if verbose {
+                            logTranslationResult(to: targetLanguage, result: translatedString.truncatedRemovingNewlines(to: 64), isSource: isSource)
+                        }
+                    } catch {
+                        logTranslationResult(to: targetLanguage, result: "[Error: \(error.localizedDescription)]".red, isSource: isSource)
+                    }
                 }
-            } catch {
-                logTranslationResult(to: targetLanguage, result: "[Error: \(error.localizedDescription)]".red, isSource: isSource)
             }
         }
     }


### PR DESCRIPTION
I started using this project for my own app, and I found it a bit slow, so I decided to improve it.
I added a `taskGroup` in the `translate(key:, catalog:)` function to request all the translations for a defined key together and wait for them before moving to the following key.

This allows the tool to be around 10x faster.