### PR TITLE
Added Chinese traditional and simplified

### DIFF
--- a/README.md
+++ b/README.md
@@ -12,7 +12,7 @@ https://github.com/hidden-spectrum/swift-translate/assets/469799/ae5066fa-336c-4
 
 ## ⭐️ Features
 - ✅ Translate individual string catalogs or all catalogs in a folder
-- ✅ Translate from English to ar, ca, zh-HK, hr, cs, da, nl, en, fi, fr, de, el, he, hi, hu, id, it, ja, ko, ms, nb, pl, pt-BR, pt-PT, ro, ru, sk, es, sv, th, tr
+- ✅ Translate from English to ar, ca, zh-HK, zh-Hans, zh-Hant, hr, cs, da, nl, en, fi, fr, de, el, he, hi, hu, id, it, ja, ko, ms, nb, pl, pt-BR, pt-PT, ro, ru, sk, es, sv, th, tr
 - ✅ Support for complex string catalogs with plural & device variations or replacements
 - ✅ Translate brand new catalogs or fill in missing translations for existing catalogs
 - ✅ Supports ChatGPT (3.5-Turbo and 4o models) and Google Translate (v2)

--- a/Sources/SwiftStringCatalog/Models/Language.swift
+++ b/Sources/SwiftStringCatalog/Models/Language.swift
@@ -37,6 +37,8 @@ public extension Language {
             .arabic,
             .catalan,
             .chineseHongKong,
+            .chineseSimplified,
+            .chineseTraditional,
             .croatian,
             .czech,
             .danish,
@@ -71,6 +73,8 @@ public extension Language {
     static let arabic = Self("ar")
     static let catalan = Self("ca")
     static let chineseHongKong = Self("zh-HK")
+    static let chineseSimplified = Self("zh-Hans")
+    static let chineseTraditional = Self("zh-Hant")
     static let croatian = Self("hr")
     static let czech = Self("cs")
     static let danish = Self("da")


### PR DESCRIPTION
I added Chinese Traditional (zh-Hant) and Chinese simplified (zh-Hans) to possible options.

Chiese HongKong is closer to Chinese traditional whereas on China mainland Chinese Simplified is the standard nowadays