### PR TITLE
Add Retry Feature

### DIFF
--- a/Sources/SwiftTranslate/Bootstrap/SwiftTranslate.swift
+++ b/Sources/SwiftTranslate/Bootstrap/SwiftTranslate.swift
@@ -55,6 +55,12 @@ struct SwiftTranslate: AsyncParsableCommand {
     )
     var skipConfirmation: Bool = false
     
+    @Option(
+        name: [.customLong("retries"), .short],
+        help: "Retries for OpenAI API requests in case of errors. Ignored when using Google Translate"
+    )
+    private var requestRetry: Int = 1
+
     @Flag(
         name: [.long, .short],
         help: "Enables verbose log output"
@@ -74,7 +80,7 @@ struct SwiftTranslate: AsyncParsableCommand {
         case .google:
             translator = GoogleTranslator(apiKey: apiToken)
         case .openAI:
-            translator = OpenAITranslator(with: apiToken, model: model)
+            translator = OpenAITranslator(with: apiToken, model: model, retries: requestRetry)
         }
         
         var targetLanguages: Set<Language>?


### PR DESCRIPTION
I noticed that sometimes, OpenAI API goes into a timeout, and the translation doesn't happen.
I fixed this with a basic retry feature based on `repeat-while`.

I also added a new Command Line option `retry` (short version `r`) to pass this value.
The default value is `1` so that the behavior is the same as before.