### PR TITLE
Add Combined Translation Service

### DIFF
--- a/Sources/SwiftTranslate/Bootstrap/SwiftTranslate.swift
+++ b/Sources/SwiftTranslate/Bootstrap/SwiftTranslate.swift
@@ -21,10 +21,11 @@ struct SwiftTranslate: AsyncParsableCommand {
 
     @Option(
         name: [.customLong("api-key"), .customShort("k")],
+        parsing: .upToNextOption,
         help: "OpenAI or Google Cloud Translate (v2) API key"
     )
-    private var apiToken: String
-    
+    private var apiToken: [String]
+
     @Option(
         name: [.customLong("model"), .customShort("m")],
         help: "OpenAI model to use. Either `gpt-3.5-turbo` (default) or `gpt-4o`. Ignored when using Google Translate"
@@ -72,11 +73,28 @@ struct SwiftTranslate: AsyncParsableCommand {
         
         switch service {
         case .google:
+            guard let apiToken = apiToken.first else {
+                throw ValidationError("Google Cloud Translate API key is required")
+            }
             translator = GoogleTranslator(apiKey: apiToken)
         case .openAI:
+            guard let apiToken = apiToken.first else {
+                throw ValidationError("OpenAI API key is required")
+            }
             translator = OpenAITranslator(with: apiToken, model: model)
+        case .combined:
+            guard apiToken.count == 2 else {
+                throw ValidationError("Two API keys are required for combined translation")
+            }
+            let apiToken = apiToken.sorted { $0.count < $1.count }
+            let googleAPIToken = String(apiToken[0])
+            let openAIAPIToken = String(apiToken[1])
+            translator = CombinedTranslator(
+                google: GoogleTranslator(apiKey: googleAPIToken),
+                openAI: OpenAITranslator(with: openAIAPIToken, model: model)
+            )
         }
-        
+
         var targetLanguages: Set<Language>?
         if languages.first?.rawValue == "__in_catalog" {
             targetLanguages = nil

--- a/Sources/SwiftTranslate/Bootstrap/TranslationCoordinator.swift
+++ b/Sources/SwiftTranslate/Bootstrap/TranslationCoordinator.swift
@@ -53,7 +53,7 @@ struct TranslationCoordinator {
     private func translate(_ string: String, to targetLanguages: Set<Language>) async throws {
         Log.info(newline: .before, "Translating `", string, "`:")
         for language in targetLanguages {
-            let translation = try await translator.translate(string, to: language, comment: nil)
+            let translation = try await translator.translate(string, to: language, comment: nil, baseTranslation: nil)
             Log.structured(
                 .init(width: 8, language.rawValue + ":"),
                 .init(translation)

--- a/Sources/SwiftTranslate/FileTranslators/StringCatalogTranslator.swift
+++ b/Sources/SwiftTranslate/FileTranslators/StringCatalogTranslator.swift
@@ -79,7 +79,8 @@ struct StringCatalogTranslator: FileTranslator {
                 let translatedString = try await service.translate(
                     localizableString.sourceKey,
                     to: targetLanguage,
-                    comment: localizableStringGroup.comment
+                    comment: localizableStringGroup.comment,
+                    baseTranslation: nil
                 )
                 localizableString.setTranslation(translatedString)
                 if verbose {

--- a/Sources/SwiftTranslate/Models/TranslationServiceArgument.swift
+++ b/Sources/SwiftTranslate/Models/TranslationServiceArgument.swift
@@ -8,5 +8,6 @@ import Foundation
 
 public enum TranslationServiceArgument: String, ExpressibleByArgument {
     case openAI = "openai"
-    case google = "google"
+    case google
+    case combined
 }

--- a/Sources/SwiftTranslate/Protocols/TranslationService.swift
+++ b/Sources/SwiftTranslate/Protocols/TranslationService.swift
@@ -7,5 +7,5 @@ import SwiftStringCatalog
 
 
 public protocol TranslationService {
-    func translate(_ string: String, to targetLanguage: Language, comment: String?) async throws -> String
+    func translate(_ string: String, to targetLanguage: Language, comment: String?, baseTranslation: String?) async throws -> String
 }

--- a/Sources/SwiftTranslate/TranslationServices/CombinedTranslator.swift
+++ b/Sources/SwiftTranslate/TranslationServices/CombinedTranslator.swift
@@ -1,0 +1,30 @@
+//
+//  Copyright © 2024 Hidden Spectrum, LLC.
+//
+
+import Foundation
+import Rainbow
+import SwiftStringCatalog
+
+
+struct CombinedTranslator {
+
+    // MARK: Private
+
+    private let googleTranslator: GoogleTranslator
+    private let openAITranslator: OpenAITranslator
+
+    // MARK: Lifecycle
+
+    init(google: GoogleTranslator, openAI: OpenAITranslator) {
+        self.googleTranslator = google
+        self.openAITranslator = openAI
+    }
+}
+
+extension CombinedTranslator: TranslationService {
+    func translate(_ string: String, to targetLanguage: Language, comment: String?, baseTranslation: String?) async throws -> String {
+        let googleTranslation = try await googleTranslator.translate(string, to: targetLanguage, comment: comment, baseTranslation: nil)
+        return try await openAITranslator.translate(string, to: targetLanguage, comment: nil, baseTranslation: googleTranslation)
+    }
+}

--- a/Sources/SwiftTranslate/TranslationServices/GoogleTranslator.swift
+++ b/Sources/SwiftTranslate/TranslationServices/GoogleTranslator.swift
@@ -12,7 +12,6 @@ struct GoogleTranslator {
     // MARK: Private
     
     private let apiKey: String
-    private let apiUrl = URL(string: "https://translation.googleapis.com/language/translate/v2")!
     
     // MARK: Lifecycle
     
@@ -45,7 +44,7 @@ struct GoogleTranslator {
 }
 
 extension GoogleTranslator: TranslationService {
-    func translate(_ string: String, to targetLanguage: Language, comment: String?) async throws -> String {
+    func translate(_ string: String, to targetLanguage: Language, comment: String?, baseTranslation: String?) async throws -> String {
         if targetLanguage == .english {
             return string
         }

--- a/Sources/SwiftTranslate/TranslationServices/OpenAITranslator.swift
+++ b/Sources/SwiftTranslate/TranslationServices/OpenAITranslator.swift
@@ -24,8 +24,8 @@ struct OpenAITranslator {
     
     // MARK: Helpers
     
-    private func chatQuery(for translatableText: String, targetLanguage: Language, comment: String?) -> ChatQuery {
-        
+    private func chatQuery(for translatableText: String, targetLanguage: Language, comment: String? = nil, baseTranslation: String? = nil) -> ChatQuery {
+
         var systemPrompt =
             """
             You are a helpful assistant designed to translate the given text from English to the language with ISO 639-1 code: \(targetLanguage.rawValue)
@@ -35,7 +35,10 @@ struct OpenAITranslator {
         if let comment {
             systemPrompt += "\n- IMPORTANT: Take into account the following context when translating: \(comment)\n"
         }
-        
+        if let baseTranslation {
+            systemPrompt += "\nUse the following already translated text \"\(baseTranslation)\" as starting point for your translation."
+        }
+
         return ChatQuery(
             messages: [
                 .system(.init(content: systemPrompt)),
@@ -53,7 +56,7 @@ extension OpenAITranslator: TranslationService {
     
     // MARK: Translate
     
-    func translate(_ string: String, to targetLanguage: Language, comment: String?) async throws -> String {
+    func translate(_ string: String, to targetLanguage: Language, comment: String?, baseTranslation: String?) async throws -> String {
         guard !string.isEmpty else {
             return string
         }


### PR DESCRIPTION
One way to get better translations is to ask Google Translate to do it first and then pass its result to OpenAI.

This PR adds a new `CombinedTranslator` service, which does this.
This requires 2 API Keys in input, of course. So the input parameter `api-key` (or `k`) is now an array.

Google Translate API Key is much shorter than the OpenAI one, so the order in the array doesn't matter, the tool can automatically understand which one to use for what, thanks to `let apiToken = apiToken.sorted { $0.count < $1.count }`.