### PR TITLE
Improve Terminal Errors

### DIFF
--- a/Sources/SwiftTranslate/Bootstrap/SwiftTranslate.swift
+++ b/Sources/SwiftTranslate/Bootstrap/SwiftTranslate.swift
@@ -67,7 +67,7 @@ struct SwiftTranslate: AsyncParsableCommand {
     
     // MARK: Lifecycle
     
-    func run() async throws {
+    func run() async {
         do {
             var translator: TranslationService
 


### PR DESCRIPTION
This PR tries to improve the error messages in the Terminal.

It just wraps the `run` function content in a `do-catch` and prints the error with `.red`.
Also, the default error doesn't give much information, and the actual error might be missed as it is not highlighted in any way.

| Old | New |
|-----|-----|
| <img width="988" alt="Screenshot 2024-11-29 at 16 52 19" src="https://github.com/user-attachments/assets/4498eda3-9cbd-4cf7-894f-770308095fa7"> | <img width="247" alt="Screenshot 2024-11-29 at 16 52 34" src="https://github.com/user-attachments/assets/cd332adc-47af-48b5-b180-0bcc1844127e"> |
