### PR TITLE
Add Timeout Option

### DIFF
--- a/Sources/SwiftTranslate/Bootstrap/SwiftTranslate.swift
+++ b/Sources/SwiftTranslate/Bootstrap/SwiftTranslate.swift
@@ -54,7 +54,13 @@ struct SwiftTranslate: AsyncParsableCommand {
         help: "Skips confirmation for translating large string files"
     )
     var skipConfirmation: Bool = false
-    
+
+    @Option(
+        name: [.customLong("timeout")],
+        help: "Timeout interval for OpenAI API requests"
+    )
+    private var timeoutInterval: Int = 60
+
     @Flag(
         name: [.long, .short],
         help: "Enables verbose log output"
@@ -72,9 +78,9 @@ struct SwiftTranslate: AsyncParsableCommand {
         
         switch service {
         case .google:
-            translator = GoogleTranslator(apiKey: apiToken)
+            translator = GoogleTranslator(apiKey: apiToken, timeoutInterval: timeoutInterval)
         case .openAI:
-            translator = OpenAITranslator(with: apiToken, model: model)
+            translator = OpenAITranslator(with: apiToken, model: model, timeoutInterval: timeoutInterval)
         }
         
         var targetLanguages: Set<Language>?

--- a/Sources/SwiftTranslate/Bootstrap/SwiftTranslate.swift
+++ b/Sources/SwiftTranslate/Bootstrap/SwiftTranslate.swift
@@ -63,7 +63,7 @@ struct SwiftTranslate: AsyncParsableCommand {
 
     @Option(
         name: [.customLong("timeout")],
-        help: "Timeout interval for OpenAI API requests"
+        help: "Timeout interval for API requests"
     )
     private var timeoutInterval: Int = 60
 

--- a/Sources/SwiftTranslate/TranslationServices/GoogleTranslator.swift
+++ b/Sources/SwiftTranslate/TranslationServices/GoogleTranslator.swift
@@ -13,11 +13,13 @@ struct GoogleTranslator {
     
     private let apiKey: String
     private let apiUrl = URL(string: "https://translation.googleapis.com/language/translate/v2")!
-    
+    private let timeoutInterval: TimeInterval
+
     // MARK: Lifecycle
     
-    init(apiKey: String) {
+    init(apiKey: String, timeoutInterval: Int) {
         self.apiKey = apiKey
+        self.timeoutInterval = TimeInterval(timeoutInterval)
     }
     
     // MARK: Utility
@@ -38,7 +40,7 @@ struct GoogleTranslator {
             throw SwiftTranslateError.couldNotCreateGoogleTranslateURL
         }
         
-        var request = URLRequest(url: url)
+        var request = URLRequest(url: url, timeoutInterval: timeoutInterval)
         request.httpMethod = "POST"
         return request
     }

--- a/Sources/SwiftTranslate/TranslationServices/OpenAITranslator.swift
+++ b/Sources/SwiftTranslate/TranslationServices/OpenAITranslator.swift
@@ -17,8 +17,8 @@ struct OpenAITranslator {
     
     // MARK: Lifecycle
     
-    init(with apiToken: String, model: OpenAIModel) {
-        self.openAI = OpenAI(apiToken: apiToken)
+    init(with apiToken: String, model: OpenAIModel, timeoutInterval: Int) {
+        self.openAI = OpenAI(configuration: OpenAI.Configuration(token: apiToken, timeoutInterval: TimeInterval(timeoutInterval)))
         self.model = model
     }
     


### PR DESCRIPTION
I noticed that OpenAI API often fails because of the request's timeout. Also, if the API doesn't reply within a very small amount of milliseconds, most likely it will never do, hence it will go in timeout.

This PR, together with #44, will "avoid" this issue by adding a new `timeout` option that should ideally be set to 3-5 seconds.

The default value is the same as now, `60` seconds.

I didn't add a short `-t` option because it is already used by the `text` option, but I'm open to any suggestion for it.