### PR TITLE
Improve OpenAI Prompt

### DIFF
--- a/Sources/SwiftTranslate/TranslationServices/OpenAITranslator.swift
+++ b/Sources/SwiftTranslate/TranslationServices/OpenAITranslator.swift
@@ -28,12 +28,17 @@ struct OpenAITranslator {
         
         var systemPrompt =
             """
-            You are a helpful assistant designed to translate the given text from English to the language with ISO 639-1 code: \(targetLanguage.rawValue)
+            You are a helpful professional translator designated to translate text from English to the language with ISO 639-1 code: \(targetLanguage.rawValue)
             If the input text contains argument placeholders (%arg, @arg1, %lld, etc), it's important they are preserved in the translated text.
             You should not output anything other than the translated text.
+            Avoid using the same word more than once in a row.
+            Avoid using the same character more than 3 times in a row.
+            Trim extra spaces and the beginning and end of the translated text.
+            Do not provide blank translations. Do not hallucinate. Do not provide translations that are not faithful to the original text.
+            Put particular attention to languages that use different characters and symbols than English.
             """
         if let comment {
-            systemPrompt += "\n- IMPORTANT: Take into account the following context when translating: \(comment)\n"
+            systemPrompt += "\nTake into consideration the following context when translating, but do not completely change the translation because of it: \(comment)\n"
         }
         
         return ChatQuery(


### PR DESCRIPTION
While translating my project, I noticed that OpenAI API sometimes translated incorrectly.

This is especially true for the `he`, `hi`, and `el` languages. That's why I added a sentence to pay particular attention to languages that use different characters and symbols than English.

I also noticed that sometimes some translations are entirely changed because of the `comment` in the strings file, that's why I added to not completely change the translations because of them.

Sometimes, a blank translation may also be returned. Or with a word or character repeated multiple times.

This prompt has given me the best result so far. This PR, together with #45, will return the best possible translation.