### PR TITLE
Add Google AI Gemini Service

### DIFF
--- a/Package.resolved
+++ b/Package.resolved
@@ -1,6 +1,14 @@
 {
-  "originHash" : "071676d25da1757ee1707bea68390c034d7e4abce3826204326b59486b00c766",
   "pins" : [
+    {
+      "identity" : "generative-ai-swift",
+      "kind" : "remoteSourceControl",
+      "location" : "https://github.com/google-gemini/generative-ai-swift",
+      "state" : {
+        "revision" : "44b8ce120425f9cf53ca756f3434ca2c2696f8bd",
+        "version" : "0.5.6"
+      }
+    },
     {
       "identity" : "openai",
       "kind" : "remoteSourceControl",
@@ -29,5 +37,5 @@
       }
     }
   ],
-  "version" : 3
+  "version" : 2
 }

--- a/Package.swift
+++ b/Package.swift
@@ -27,7 +27,7 @@ let package = Package(
         .package(url: "https://github.com/apple/swift-argument-parser", .upToNextMajor(from: "1.5.0")),
         .package(url: "https://github.com/MacPaw/OpenAI.git", .upToNextMajor(from: "0.3.0")),
         .package(url: "https://github.com/onevcat/Rainbow.git", .upToNextMajor(from: "4.0.0")),
-        .package(url: "https://github.com/google-gemini/generative-ai-swift", .upToNextMajor(from: "0.1.0")),
+        .package(url: "https://github.com/google-gemini/generative-ai-swift", .upToNextMajor(from: "0.5.0")),
     ],
     targets: [
         

--- a/Package.swift
+++ b/Package.swift
@@ -27,6 +27,7 @@ let package = Package(
         .package(url: "https://github.com/apple/swift-argument-parser", .upToNextMajor(from: "1.5.0")),
         .package(url: "https://github.com/MacPaw/OpenAI.git", .upToNextMajor(from: "0.3.0")),
         .package(url: "https://github.com/onevcat/Rainbow.git", .upToNextMajor(from: "4.0.0")),
+        .package(url: "https://github.com/google-gemini/generative-ai-swift", .upToNextMajor(from: "0.1.0")),
     ],
     targets: [
         
@@ -57,6 +58,7 @@ let package = Package(
                 .product(name: "ArgumentParser", package: "swift-argument-parser"),
                 .product(name: "OpenAI", package: "OpenAI"),
                 .product(name: "Rainbow", package: "Rainbow"),
+                .product(name: "GoogleGenerativeAI", package: "generative-ai-swift"),
                 "SwiftStringCatalog"
             ],
             path: "Sources/SwiftTranslate"

--- a/README.md
+++ b/README.md
@@ -8,14 +8,14 @@ https://github.com/hidden-spectrum/swift-translate/assets/469799/ae5066fa-336c-4
 - macOS 13+
 - Xcode 15+
 - Project utilizing [String Catalogs](https://developer.apple.com/videos/play/wwdc2023/10155/) for localization
-- [OpenAI API key](https://help.openai.com/en/articles/4936850-where-do-i-find-my-openai-api-key) or [Google Cloud Translate (v2)](https://cloud.google.com/translate/docs/overview) API key
+- [OpenAI API key](https://help.openai.com/en/articles/4936850-where-do-i-find-my-openai-api-key), [Google Cloud Translate (v2) API key](https://cloud.google.com/translate/docs/overview), or [Gemini API key](https://ai.google.dev/gemini-api/docs).
 
 ## ⭐️ Features
 - ✅ Translate individual string catalogs or all catalogs in a folder
 - ✅ Translate from English to ar, ca, zh-HK, zh-Hans, zh-Hant, hr, cs, da, nl, en, fi, fr, de, el, he, hi, hu, id, it, ja, ko, ms, nb, pl, pt-BR, pt-PT, ro, ru, sk, es, sv, th, tr
 - ✅ Support for complex string catalogs with plural & device variations or replacements
 - ✅ Translate brand new catalogs or fill in missing translations for existing catalogs
-- ✅ Supports ChatGPT (3.5-Turbo and 4o models) and Google Translate (v2)
+- ✅ Supports ChatGPT (3.5-Turbo and 4o models), Google Translate (v2), and Gemini 1.5 Flash and 2.0 Flash models
 - 🚧 Documentation ([#2](/../../issues/2))
 - 🚧 Unit tests ([#3](/../../issues/3))
 - ❌ Translate from non-English source language ([#23](/../../issues/23))

--- a/Sources/SwiftTranslate/Bootstrap/SwiftTranslate.swift
+++ b/Sources/SwiftTranslate/Bootstrap/SwiftTranslate.swift
@@ -86,8 +86,8 @@ struct SwiftTranslate: AsyncParsableCommand {
             translator = GoogleTranslator(apiKey: apiToken)
         case .openAI:
             translator = OpenAITranslator(with: apiToken, model: model, retries: requestRetry)
-        case .googleAI:
-            translator = GoogleAITranslator(apiKey: apiToken, model: model)
+        case .gemini:
+            translator = GeminiTranslator(apiKey: apiToken, model: model)
         }
         
         var targetLanguages: Set<Language>?

--- a/Sources/SwiftTranslate/Bootstrap/SwiftTranslate.swift
+++ b/Sources/SwiftTranslate/Bootstrap/SwiftTranslate.swift
@@ -30,7 +30,7 @@ struct SwiftTranslate: AsyncParsableCommand {
         help: """
             AI model to use. 
             Either `gpt-3.5-turbo` (default) or `gpt-4o` for OpenAI.
-            Either `gemini-1.5-flash` or `gemini-2.0-flash-exp` for Google AI.
+            Either `gemini-1.5-flash` or `gemini-2.0-flash` for Google AI.
             Ignored when using Google Translate.
             """
     )

--- a/Sources/SwiftTranslate/Bootstrap/SwiftTranslate.swift
+++ b/Sources/SwiftTranslate/Bootstrap/SwiftTranslate.swift
@@ -27,9 +27,14 @@ struct SwiftTranslate: AsyncParsableCommand {
     
     @Option(
         name: [.customLong("model"), .customShort("m")],
-        help: "OpenAI model to use. Either `gpt-3.5-turbo` (default) or `gpt-4o`. Ignored when using Google Translate"
+        help: """
+            AI model to use. 
+            Either `gpt-3.5-turbo` (default) or `gpt-4o` for OpenAI.
+            Either `gemini-1.5-flash` or `gemini-2.0-flash-exp` for Google AI.
+            Ignored when using Google Translate.
+            """
     )
-    private var model: OpenAIModel = .gpt3_5Turbo
+    private var model: AIModel = .gpt3_5Turbo
     
     @OptionGroup(
         title: "Translate text"
@@ -75,6 +80,8 @@ struct SwiftTranslate: AsyncParsableCommand {
             translator = GoogleTranslator(apiKey: apiToken)
         case .openAI:
             translator = OpenAITranslator(with: apiToken, model: model)
+        case .googleAI:
+            translator = GoogleAITranslator(apiKey: apiToken, model: model)
         }
         
         var targetLanguages: Set<Language>?

--- a/Sources/SwiftTranslate/Models/AIModel.swift
+++ b/Sources/SwiftTranslate/Models/AIModel.swift
@@ -6,7 +6,9 @@ import ArgumentParser
 import Foundation
 
 
-public enum OpenAIModel: String, ExpressibleByArgument {
+public enum AIModel: String, ExpressibleByArgument {
     case gpt3_5Turbo = "gpt-3.5-turbo"
     case gpt4o = "gpt-4o"
+    case gemini15 = "gemini-1.5-flash"
+    case gemini20 = "gemini-2.0-flash-exp"
 }

--- a/Sources/SwiftTranslate/Models/AIModel.swift
+++ b/Sources/SwiftTranslate/Models/AIModel.swift
@@ -9,6 +9,7 @@ import Foundation
 public enum AIModel: String, ExpressibleByArgument {
     case gpt3_5Turbo = "gpt-3.5-turbo"
     case gpt4o = "gpt-4o"
+    case gpt4o_mini = "gpt-4o-mini"
     case gemini15 = "gemini-1.5-flash"
     case gemini20 = "gemini-2.0-flash"
 }

--- a/Sources/SwiftTranslate/Models/AIModel.swift
+++ b/Sources/SwiftTranslate/Models/AIModel.swift
@@ -10,5 +10,5 @@ public enum AIModel: String, ExpressibleByArgument {
     case gpt3_5Turbo = "gpt-3.5-turbo"
     case gpt4o = "gpt-4o"
     case gemini15 = "gemini-1.5-flash"
-    case gemini20 = "gemini-2.0-flash-exp"
+    case gemini20 = "gemini-2.0-flash"
 }

--- a/Sources/SwiftTranslate/Models/TranslationServiceArgument.swift
+++ b/Sources/SwiftTranslate/Models/TranslationServiceArgument.swift
@@ -9,4 +9,5 @@ import Foundation
 public enum TranslationServiceArgument: String, ExpressibleByArgument {
     case openAI = "openai"
     case google = "google"
+    case googleAI = "googleai"
 }

--- a/Sources/SwiftTranslate/Models/TranslationServiceArgument.swift
+++ b/Sources/SwiftTranslate/Models/TranslationServiceArgument.swift
@@ -9,5 +9,5 @@ import Foundation
 public enum TranslationServiceArgument: String, ExpressibleByArgument {
     case openAI = "openai"
     case google = "google"
-    case googleAI = "googleai"
+    case gemini = "gemini"
 }

--- a/Sources/SwiftTranslate/TranslationServices/GeminiTranslator.swift
+++ b/Sources/SwiftTranslate/TranslationServices/GeminiTranslator.swift
@@ -6,7 +6,7 @@ import Foundation
 import GoogleGenerativeAI
 import SwiftStringCatalog
 
-struct GoogleAITranslator {
+struct GeminiTranslator {
 
     // MARK: Private
 
@@ -21,7 +21,7 @@ struct GoogleAITranslator {
     }
 }
 
-extension GoogleAITranslator: TranslationService {
+extension GeminiTranslator: TranslationService {
     func translate(_ string: String, to targetLanguage: Language, comment: String?) async throws -> String {
         let generativeModel =
         GenerativeModel(

--- a/Sources/SwiftTranslate/TranslationServices/GoogleAITranslator.swift
+++ b/Sources/SwiftTranslate/TranslationServices/GoogleAITranslator.swift
@@ -1,0 +1,52 @@
+//
+//  Copyright © 2024 Hidden Spectrum, LLC.
+//
+
+import Foundation
+import GoogleGenerativeAI
+import SwiftStringCatalog
+
+struct GoogleAITranslator {
+
+    // MARK: Private
+
+    private let apiKey: String
+    private let model: AIModel
+
+    // MARK: Lifecycle
+
+    init(apiKey: String, model: AIModel) {
+        self.apiKey = apiKey
+        self.model = model
+    }
+}
+
+extension GoogleAITranslator: TranslationService {
+    func translate(_ string: String, to targetLanguage: Language, comment: String?) async throws -> String {
+        let generativeModel =
+        GenerativeModel(
+            name: model.rawValue,
+            apiKey: apiKey
+        )
+
+        var prompt = """
+            You are a helpful assistant designed to translate the given text from English to the language with ISO 639-1 code: \(targetLanguage.rawValue)
+            If the input text contains argument placeholders (%arg, @arg1, %lld, etc), it's important they are preserved in the translated text.
+            You should not output anything other than the translated text.
+            """
+        if let comment {
+            prompt += "\n- IMPORTANT: Take into account the following context when translating: \(comment)\n"
+        }
+
+        prompt += string
+
+        let response = try await generativeModel.generateContent(prompt)
+        guard var responseText = response.text else {
+            throw SwiftTranslateError.noTranslationReturned
+        }
+        // Last character is a newline, need to remove it.
+        responseText.removeLast()
+
+        return responseText
+    }
+}

--- a/Sources/SwiftTranslate/TranslationServices/OpenAITranslator.swift
+++ b/Sources/SwiftTranslate/TranslationServices/OpenAITranslator.swift
@@ -13,11 +13,11 @@ struct OpenAITranslator {
     // MARK: Private
     
     private let openAI: OpenAI
-    private let model: OpenAIModel
+    private let model: AIModel
     
     // MARK: Lifecycle
     
-    init(with apiToken: String, model: OpenAIModel) {
+    init(with apiToken: String, model: AIModel) {
         self.openAI = OpenAI(apiToken: apiToken)
         self.model = model
     }


### PR DESCRIPTION
I added the Google AI option to be used as a translation provider.
The available models are Gemini 1.5 flash and Gemini 2.0 flash (which are still being experimented with).

To achieve this, I had to make models generic and add the Gemini ones.

Adding a separate option can be considered because a user can now use `gpt-4o` and then select `gemini` as a service.
Of course, an error will be thrown, but it's not the best user experience.

If #48 gets approved, those changes should be applied here too.

If #45 gets approved, will need to think about how to specify which combination to use. Maybe add a new option for the `combined` service to specify which services to use.